### PR TITLE
update `const` to `var`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const UTF8_ACCEPT = 12
-const UTF8_REJECT = 0
-const UTF8_DATA = [
+var UTF8_ACCEPT = 12
+var UTF8_REJECT = 0
+var UTF8_DATA = [
   // The first part of the table maps bytes to character to a transition.
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -82,7 +82,7 @@ function decodeURIComponent (uri) {
   return decoded + uri.slice(last)
 }
 
-const HEX = {
+var HEX = {
   '0': 0,
   '1': 1,
   '2': 2,


### PR DESCRIPTION
The use of `const` is problematic:
1. This script also uses `"use strict";` which causes Safari to refuse to run the script.
2. Older browsers such as IE and some Edge do not support `const`.
3. Many build systems do not run transforms on npm modules. In Webpack, for example, it is common to exclude /node_modules/ from running through babel.